### PR TITLE
Fix when selecting date in IE 10 & 11

### DIFF
--- a/polymer-date-picker-calendar.html
+++ b/polymer-date-picker-calendar.html
@@ -45,7 +45,7 @@
         this.moveMonth(1);
       },
       dateClicked: function(e) {
-        var element = e.originalTarget ? e.originalTarget : e.toElement;
+        var element = e.originalTarget || e.toElement || e.srcElement;
         var row = element.getAttribute("row");
         var col = element.getAttribute("col");
         this.selectedDate = this.calendar[row][col].identifier;


### PR DESCRIPTION
This is to fix the issue that I raised before. IE10 and 11 is throwing error when selecting date. IE understands e.srcElement.
